### PR TITLE
FIxing System.Collections.Immutable constraint for umbraco 8.16.0

### DIFF
--- a/Source/Cogworks.Essentials/Cogworks.Essentials.csproj
+++ b/Source/Cogworks.Essentials/Cogworks.Essentials.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.11.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.12.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/Cogworks.Essentials/Cogworks.Essentials.nuspec
+++ b/Source/Cogworks.Essentials/Cogworks.Essentials.nuspec
@@ -17,7 +17,6 @@
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Extensions.Caching.Memory" version="5.0.0" />
         <dependency id="Microsoft.IdentityModel.Tokens" version="6.11.0" />
-        <dependency id="System.Collections.Immutable" version="5.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Source/tests/UnitTests/Cogworks.Essentials.UnitTests/Cogworks.Essentials.UnitTests.csproj
+++ b/Source/tests/UnitTests/Cogworks.Essentials.UnitTests/Cogworks.Essentials.UnitTests.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
@@ -21,11 +21,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This change is needed in order to use this package in the latest umbraco 8.16.0, this version has this constraint: System.Collections.Immutable (>= 1.7.1 && < 1.999999.0)